### PR TITLE
Hotfix/7 clean build error

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ cd bin
 아래 명령어로 빌드된 파일 실행
 ```
 cd build/libs
-java -jar jpashop-0.0.1-SNAPSHOT.jar
+java -jar baedalmate-0.0.1-SNAPSHOT.jar
 ```
 
 [localhot:8080](localhot:8080) 접속

--- a/src/test/java/baedalmate/baedalmate/BaedalmateApplicationTests.java
+++ b/src/test/java/baedalmate/baedalmate/BaedalmateApplicationTests.java
@@ -3,7 +3,7 @@ package baedalmate.baedalmate;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+//@SpringBootTest
 class BaedalmateApplicationTests {
 
 	@Test


### PR DESCRIPTION
## 개요
- 젠킨스 배포시 빌드 오류 발생
- test가 원인
- BaedalmateApplicationTest 클래스의 @SpringBootTest Annotation을 제거하여 해결

## 작업사항
- BaedalmateApplicationTest 클래스의 @SpringBootTest Annotation을 제거

## 변경로직
