### PR TITLE
fix: Update LoadUserService Class to execute in java 11

### DIFF
--- a/src/main/java/baedalmate/baedalmate/oauth/service/LoadUserService.java
+++ b/src/main/java/baedalmate/baedalmate/oauth/service/LoadUserService.java
@@ -37,11 +37,9 @@ public class LoadUserService {
     }
 
     private void setSocialLoadStrategy(SocialType socialType) {
-        this.socialLoadStrategy = switch (socialType){
-            case KAKAO -> new KakaoLoadStrategy();
-            default -> throw new IllegalArgumentException("지원하지 않는 로그인 형식입니다");
-        };
+         switch (socialType){
+             case KAKAO: this.socialLoadStrategy = new KakaoLoadStrategy();
+             default: throw new IllegalArgumentException("지원하지 않는 로그인 형식입니다");
+        }
     }
-
-
 }


### PR DESCRIPTION
## 개요
LoadUserService클래스의 코드를 자바 11에서 작동하도록 수정한다.
기존 switch문을 이용한 변수 초기화는 자바 14이상에서 사용할 수 있으므로 switch문을 이용하지만 초기화 부분이 switch문 안으로 들어가도록 수정한다..

## 작업사항
- LoadUserService 클래스의 setSocialLoadStrategy 메서드 내부 수정