### PR TITLE
fix(swagger): Update Controllers

### DIFF
--- a/src/main/java/baedalmate/baedalmate/api/AuthApiController.java
+++ b/src/main/java/baedalmate/baedalmate/api/AuthApiController.java
@@ -2,6 +2,7 @@ package baedalmate.baedalmate.api;
 
 import baedalmate.baedalmate.oauth.provider.TokenProvider;
 import baedalmate.baedalmate.repository.UserRepository;
+import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.Data;
 import lombok.Getter;
@@ -10,6 +11,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
+@Api(tags = {"인증 api"})
 @Controller
 @RequiredArgsConstructor
 public class AuthApiController {

--- a/src/main/java/baedalmate/baedalmate/api/RecruitApiController.java
+++ b/src/main/java/baedalmate/baedalmate/api/RecruitApiController.java
@@ -4,23 +4,28 @@ import baedalmate.baedalmate.dto.Result;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.awt.print.Pageable;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
 @Api(tags = {"모집글 api"})
 @RestController
+@RequestMapping("/api/v1")
 public class RecruitApiController {
 
     @ApiOperation(value = "모집글 리스트 조회")
+    @GetMapping(value = "/recruit/list")
     public Result getRecruitList(
             @ApiParam(value = "카테고리별 조회(일단 사용x)")
             @RequestParam(required = false) Long categoryId,
-            Pageable pageable
+            @ApiParam(value = "예시: {ip}:8080/production/list?page=0&size=5&sort=view,DESC")
+                    Pageable pageable
     ) {
         List<RecruitDto> collect = new ArrayList<>();
         return new Result(collect);

--- a/src/main/java/baedalmate/baedalmate/api/UserApiController.java
+++ b/src/main/java/baedalmate/baedalmate/api/UserApiController.java
@@ -1,13 +1,20 @@
 package baedalmate.baedalmate.api;
 
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Api(tags = {"유저 api"})
 @RestController
+@RequestMapping("/api/v1")
 public class UserApiController {
+
+    @ApiOperation(value = "유저 정보 조회")
+    @GetMapping(value = "/user")
     public UserDto getUserInfo() {
         return new UserDto();
     }


### PR DESCRIPTION
## 개요
- Swagger 작성 중 쿼리스트링으로 사용되는 Pageable 인터페이스의 명세 문제 발생

## 작업사항
- 요청 메서드에 Mapping annotation을 추가하지 않아 명세가 나타나지 않음. 각 요청에 Mapping 추가.
Pageable 클래스를 data.domain이 아닌 awt.print의 Pageble을 임포트하여 출력되지 않음. data.domain으로 변경.

