### PR TITLE
Feature/48 recruit category

### DIFF
--- a/src/main/java/baedalmate/baedalmate/domain/Category.java
+++ b/src/main/java/baedalmate/baedalmate/domain/Category.java
@@ -1,0 +1,35 @@
+package baedalmate.baedalmate.domain;
+
+import lombok.Getter;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+public class Category {
+    @GeneratedValue
+    @Id
+    @Column(name = "category_id")
+    private Long id;
+
+    @Column(name = "category_name")
+    private String name;
+
+    @OneToMany(mappedBy = "category")
+    private List<Recruit> recruits = new ArrayList<>();
+
+    //== 연관관계 편의 메서드 ==//
+    public void addRecruit(Recruit recruit) {
+        recruits.add(recruit);
+        recruit.setCategory(this);
+    }
+
+    //== Constructor ==//
+    public Category() {}
+
+    public Category(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/baedalmate/baedalmate/domain/Menu.java
+++ b/src/main/java/baedalmate/baedalmate/domain/Menu.java
@@ -13,6 +13,7 @@ public class Menu {
     @JoinColumn(name = "order_id")
     private Order order;
 
+    @Column(name = "menu_name")
     private String name;
 
     private int price;

--- a/src/main/java/baedalmate/baedalmate/domain/Recruit.java
+++ b/src/main/java/baedalmate/baedalmate/domain/Recruit.java
@@ -3,6 +3,7 @@ package baedalmate.baedalmate.domain;
 import baedalmate.baedalmate.domain.embed.Place;
 import lombok.Getter;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -54,8 +55,15 @@ public class Recruit {
     @OneToMany(cascade = CascadeType.ALL, mappedBy = "recruit")
     private List<Tag> tags = new ArrayList<>();
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private Category category;
+
     @CreationTimestamp
     private LocalDateTime createDate;
+
+    @UpdateTimestamp
+    private LocalDateTime updateDate;
 
     private LocalDateTime deadlineDate;
 
@@ -87,12 +95,13 @@ public class Recruit {
 
     //== 생성 메서드 ==//
     public static Recruit createRecruit(
-            User user,
+            User user, Category category,
             int minPeople, int minPrice, LocalDateTime deadlineDate, Criteria criteria, Dormitory dormitory,
             Place place, Platform platform, int coupon, String title, String description, boolean freeShipping,
             List<ShippingFee> shippingFees, Order order, List<Tag> tags) {
         Recruit recruit = new Recruit(minPeople, minPrice, deadlineDate, criteria, dormitory, place, platform, coupon, title, description, freeShipping);
-        recruit.setUser(user);
+        user.addRecruit(recruit);
+        category.addRecruit(recruit);
         for(ShippingFee shippingFee : shippingFees) {
             recruit.addShippingFee(shippingFee);
         }
@@ -106,6 +115,10 @@ public class Recruit {
     //== 연관관계 편의 메서드 ==//
     public void setUser(User user) {
         this.user = user;
+    }
+
+    public void setCategory(Category category) {
+        this.category = category;
     }
 
     public void addOrder(Order order) {
@@ -123,6 +136,9 @@ public class Recruit {
         tag.setRecruit(this);
     }
 
+    public void addCategory(Category category) {
+
+    }
     //== Getter ==//
     public int getMinShippingFee() {
         if(freeShipping) return 0;

--- a/src/main/java/baedalmate/baedalmate/domain/ShippingFee.java
+++ b/src/main/java/baedalmate/baedalmate/domain/ShippingFee.java
@@ -20,6 +20,7 @@ public class ShippingFee {
     private int upperPrice;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recruit_id")
     private Recruit recruit;
 
     //== constructor ==//

--- a/src/main/java/baedalmate/baedalmate/domain/Tag.java
+++ b/src/main/java/baedalmate/baedalmate/domain/Tag.java
@@ -12,10 +12,11 @@ public class Tag {
     @Column(name = "tag_id")
     private Long id;
 
-    @Column(name = "tagname")
+    @Column(name = "tag_name")
     private String name;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recruit_id")
     private Recruit recruit;
 
     //== constructor ==//

--- a/src/main/java/baedalmate/baedalmate/domain/User.java
+++ b/src/main/java/baedalmate/baedalmate/domain/User.java
@@ -71,5 +71,6 @@ public class User {
     //== 연관관계 편의메서드 ==//
     public void addRecruit(Recruit recruit) {
         recruits.add(recruit);
+        recruit.setUser(this);
     }
 }

--- a/src/main/java/baedalmate/baedalmate/repository/CategoryRepository.java
+++ b/src/main/java/baedalmate/baedalmate/repository/CategoryRepository.java
@@ -1,0 +1,24 @@
+package baedalmate.baedalmate.repository;
+
+import baedalmate.baedalmate.domain.Category;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+
+@Repository
+@RequiredArgsConstructor
+public class CategoryRepository {
+
+    private final EntityManager em;
+
+    public Category findOne(Long id) {
+        return em.find(Category.class, id);
+    }
+
+    public Category findByName(String name) {
+        return em.createQuery("select c from Category c where c.name = :name", Category.class)
+                .setParameter("name", name)
+                .getSingleResult();
+    }
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,11 @@
+--insert into category(category_id, category_name) values (1, '한식');
+--insert into category(category_id, category_name) values (2, '중식');
+--insert into category(category_id, category_name) values (3, '일식');
+--insert into category(category_id, category_name) values (4, '양식');
+--insert into category(category_id, category_name) values (5, '패스트푸드');
+--insert into category(category_id, category_name) values (6, '분식');
+--insert into category(category_id, category_name) values (7, '카페디저트');
+--insert into category(category_id, category_name) values (8, '치킨');
+--insert into category(category_id, category_name) values (9, '피자');
+--insert into category(category_id, category_name) values (10, '아시안');
+--insert into category(category_id, category_name) values (11, '도시락');


### PR DESCRIPTION
## 개요
- Recruit에 카테고리 적용

## 작업사항
- Category 엔티티 생성 및 연관관계 편의 메서드 생성
   - Category와 Recruit은 일대다 양방향관계

## 변경로직
- RecruitApiController의 createRecruitRequest dto에 categoryId 추가 및 createRecruit api 메서드에서 Recruit 생성 전 Category 등록
