### PR TITLE
Feature/54 recruit repository query

### DIFF
--- a/src/main/java/baedalmate/baedalmate/api/UserApiController.java
+++ b/src/main/java/baedalmate/baedalmate/api/UserApiController.java
@@ -27,7 +27,7 @@ public class UserApiController {
     public UserDto getUserInfo(
             @CurrentUser PrincipalDetails principalDetails) {
         User user = userService.findOne(principalDetails.getId());
-        return new UserDto(user.getNickname(), user.getProfileImage(), user.getAddress(), user.getDormitory());
+        return new UserDto(user.getNickname(), user.getProfileImage(), user.getAddress(), user.getDormitoryName());
     }
 
     @Data

--- a/src/main/java/baedalmate/baedalmate/domain/Recruit.java
+++ b/src/main/java/baedalmate/baedalmate/domain/Recruit.java
@@ -32,7 +32,7 @@ public class Recruit {
     private int currentPeople;
 
     @Column(columnDefinition = "integer default 0", nullable = false)
-    private int views;
+    private int view;
 
     private int minPeople;
 

--- a/src/main/java/baedalmate/baedalmate/domain/User.java
+++ b/src/main/java/baedalmate/baedalmate/domain/User.java
@@ -61,7 +61,7 @@ public class User {
         return address.getStreet() + " " + address.getDetail();
     }
 
-    public String getDormitory() {
+    public String getDormitoryName() {
         if(dormitory == null) {
             return "";
         }

--- a/src/main/java/baedalmate/baedalmate/repository/RecruitJpaRepository.java
+++ b/src/main/java/baedalmate/baedalmate/repository/RecruitJpaRepository.java
@@ -1,10 +1,35 @@
 package baedalmate.baedalmate.repository;
 
+import baedalmate.baedalmate.domain.Dormitory;
 import baedalmate.baedalmate.domain.Recruit;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface RecruitJpaRepository extends JpaRepository<Recruit, Long> {
-    Page<Recruit> findAll(Pageable pageable);
+
+    @Query("select r from Recruit r join fetch r.user u join fetch r.shippingFees where r.active = true order by u.score DESC")
+    List<Recruit> findAllUsingJoinOrderByScore(Pageable pageable);
+
+    @Query("select r from Recruit r join fetch r.user join fetch r.shippingFees where r.active = true order by r.deadlineDate ASC")
+    List<Recruit> findAllUsingJoinOrderByDeadlineDate(Pageable pageable);
+
+    @Query("select r from Recruit r join fetch r.user join fetch r.shippingFees where r.active = true order by r.view DESC")
+    List<Recruit> findAllUsingJoinOrderByView(Pageable pageable);
+
+    @Query("select r from Recruit r join fetch r.user u join fetch r.shippingFees where r.category.id = :id and r.active = true order by u.score DESC")
+    List<Recruit> findAllByCategoryUsingJoinOrderByScore(@Param("id") Long categoryId, Pageable pageable);
+
+    @Query("select r from Recruit r join fetch r.user join fetch r.shippingFees where r.category.id = :id and r.active = true order by r.deadlineDate ASC")
+    List<Recruit> findAllByCategoryUsingJoinOrderByDeadlineDate(@Param("id") Long categoryId, Pageable pageable);
+
+    @Query("select r from Recruit r join fetch r.user join fetch r.shippingFees where r.category.id = :id and r.active = true order by r.view DESC")
+    List<Recruit> findAllByCategoryUsingJoinOrderByView(@Param("id") Long categoryId, Pageable pageable);
+
+    @Query("select r from Recruit r join fetch r.user join fetch r.tags where r.dormitory = :dormitory and r.active = true order by r.deadlineDate ASC")
+    List<Recruit> findAllWithTagsUsingJoinOrderByDeadlineDate(@Param("dormitory") Dormitory dormitory, Pageable pageable);
 }

--- a/src/main/java/baedalmate/baedalmate/service/RecruitService.java
+++ b/src/main/java/baedalmate/baedalmate/service/RecruitService.java
@@ -1,13 +1,16 @@
 package baedalmate.baedalmate.service;
 
+import baedalmate.baedalmate.domain.Dormitory;
 import baedalmate.baedalmate.domain.Recruit;
 import baedalmate.baedalmate.repository.RecruitJpaRepository;
 import baedalmate.baedalmate.repository.RecruitRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -27,7 +30,35 @@ public class RecruitService {
         return recruitRepository.findOne(recruitId);
     }
 
-    public Page<Recruit> findAll(Pageable pageable) {
-        return recruitJpaRepository.findAll(pageable);
+    public List<Recruit> findAll(Pageable pageable) {
+        String sort = pageable.getSort().toString();
+        if(sort.contains("score")) {
+            return recruitJpaRepository.findAllUsingJoinOrderByScore(pageable);
+        }
+        if(sort.contains("deadlineDate")) {
+            return recruitJpaRepository.findAllUsingJoinOrderByDeadlineDate(pageable);
+        }
+        if(sort.contains("view")) {
+            return recruitJpaRepository.findAllUsingJoinOrderByView(pageable);
+        }
+        return new ArrayList<Recruit>();
+    }
+
+    public List<Recruit> findAllWithTag(Dormitory dormitory, Pageable pageable) {
+        return recruitJpaRepository.findAllWithTagsUsingJoinOrderByDeadlineDate(dormitory, pageable);
+    }
+
+    public List<Recruit> findAllByCategory(Long categoryId, Pageable pageable) {
+        String sort = pageable.getSort().toString();
+        if(sort.contains("score")) {
+            return recruitJpaRepository.findAllByCategoryUsingJoinOrderByScore(categoryId, pageable);
+        }
+        if(sort.contains("deadlineDate")) {
+            return recruitJpaRepository.findAllByCategoryUsingJoinOrderByDeadlineDate(categoryId, pageable);
+        }
+        if(sort.contains("view")) {
+            return recruitJpaRepository.findAllByCategoryUsingJoinOrderByView(categoryId, pageable);
+        }
+        return new ArrayList<Recruit>();
     }
 }


### PR DESCRIPTION
## 개요
- Recruit 조회 시 정렬 기준 구현과 성능 최적화를 위해 RecruitRepository를 수정

## 작업사항
- Recruit 조회 메서드를 @Query annotation을 이용하여 구현
   - 지연 로딩과 fetch join을 이용하여 n+1문제에 유의하여 구현함
- RecruitApiController의 메서드에 정렬 구현 
