### PR TITLE
Feature/56 recruit detail

### DIFF
--- a/src/main/java/baedalmate/baedalmate/domain/Category.java
+++ b/src/main/java/baedalmate/baedalmate/domain/Category.java
@@ -9,7 +9,7 @@ import java.util.List;
 @Entity
 @Getter
 public class Category {
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id
     @Column(name = "category_id")
     private Long id;

--- a/src/main/java/baedalmate/baedalmate/domain/Menu.java
+++ b/src/main/java/baedalmate/baedalmate/domain/Menu.java
@@ -4,7 +4,7 @@ import javax.persistence.*;
 
 @Entity
 public class Menu {
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id
     @Column(name = "menu_id")
     private Long id;

--- a/src/main/java/baedalmate/baedalmate/domain/Order.java
+++ b/src/main/java/baedalmate/baedalmate/domain/Order.java
@@ -10,7 +10,7 @@ import java.util.List;
 @Getter
 @Table(name = "orders")
 public class Order {
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id
     @Column(name = "order_id")
     private Long id;

--- a/src/main/java/baedalmate/baedalmate/domain/Recruit.java
+++ b/src/main/java/baedalmate/baedalmate/domain/Recruit.java
@@ -14,7 +14,7 @@ import java.util.List;
 @Getter
 public class Recruit {
 
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id
     @Column(name = "recruit_id")
     private Long id;

--- a/src/main/java/baedalmate/baedalmate/domain/ShippingFee.java
+++ b/src/main/java/baedalmate/baedalmate/domain/ShippingFee.java
@@ -8,7 +8,7 @@ import javax.persistence.*;
 @Getter
 public class ShippingFee {
 
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id
     @Column(name = "shipping_fee_id")
     private Long id;

--- a/src/main/java/baedalmate/baedalmate/domain/Tag.java
+++ b/src/main/java/baedalmate/baedalmate/domain/Tag.java
@@ -7,7 +7,7 @@ import javax.persistence.*;
 @Entity
 @Getter
 public class Tag {
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id
     @Column(name = "tag_id")
     private Long id;

--- a/src/main/java/baedalmate/baedalmate/domain/User.java
+++ b/src/main/java/baedalmate/baedalmate/domain/User.java
@@ -19,7 +19,7 @@ import java.util.List;
 @AllArgsConstructor
 public class User {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id")
     private Long id;
     private String nickname;

--- a/src/main/java/baedalmate/baedalmate/repository/RecruitJpaRepository.java
+++ b/src/main/java/baedalmate/baedalmate/repository/RecruitJpaRepository.java
@@ -5,6 +5,7 @@ import baedalmate.baedalmate.domain.Recruit;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -36,4 +37,8 @@ public interface RecruitJpaRepository extends JpaRepository<Recruit, Long> {
 
     @Query("select r from Recruit r join fetch r.user join fetch r.shippingFees where r.id = :id")
     Optional<Recruit> findById(@Param("id") Long recruitId);
+
+    @Modifying
+    @Query("update Recruit r set r.view = r.view + 1 where r.id = :id")
+    int updateView(Long id);
 }

--- a/src/main/java/baedalmate/baedalmate/repository/RecruitJpaRepository.java
+++ b/src/main/java/baedalmate/baedalmate/repository/RecruitJpaRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface RecruitJpaRepository extends JpaRepository<Recruit, Long> {
 
@@ -32,4 +33,7 @@ public interface RecruitJpaRepository extends JpaRepository<Recruit, Long> {
 
     @Query("select r from Recruit r join fetch r.user join fetch r.tags where r.dormitory = :dormitory and r.active = true order by r.deadlineDate ASC")
     List<Recruit> findAllWithTagsUsingJoinOrderByDeadlineDate(@Param("dormitory") Dormitory dormitory, Pageable pageable);
+
+    @Query("select r from Recruit r join fetch r.user join fetch r.shippingFees where r.id = :id")
+    Optional<Recruit> findById(@Param("id") Long recruitId);
 }

--- a/src/main/java/baedalmate/baedalmate/repository/RecruitJpaRepository.java
+++ b/src/main/java/baedalmate/baedalmate/repository/RecruitJpaRepository.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 public interface RecruitJpaRepository extends JpaRepository<Recruit, Long> {
 
-    @Query("select r from Recruit r join fetch r.user u join fetch r.shippingFees where r.active = true order by u.score DESC")
+    @Query("select r from Recruit r join fetch r.user join fetch r.shippingFees where r.active = true order by r.user.score DESC")
     List<Recruit> findAllUsingJoinOrderByScore(Pageable pageable);
 
     @Query("select r from Recruit r join fetch r.user join fetch r.shippingFees where r.active = true order by r.deadlineDate ASC")
@@ -21,7 +21,7 @@ public interface RecruitJpaRepository extends JpaRepository<Recruit, Long> {
     @Query("select r from Recruit r join fetch r.user join fetch r.shippingFees where r.active = true order by r.view DESC")
     List<Recruit> findAllUsingJoinOrderByView(Pageable pageable);
 
-    @Query("select r from Recruit r join fetch r.user u join fetch r.shippingFees where r.category.id = :id and r.active = true order by u.score DESC")
+    @Query("select r from Recruit r join fetch r.user join fetch r.shippingFees where r.category.id = :id and r.active = true order by r.user.score DESC")
     List<Recruit> findAllByCategoryUsingJoinOrderByScore(@Param("id") Long categoryId, Pageable pageable);
 
     @Query("select r from Recruit r join fetch r.user join fetch r.shippingFees where r.category.id = :id and r.active = true order by r.deadlineDate ASC")

--- a/src/main/java/baedalmate/baedalmate/service/RecruitService.java
+++ b/src/main/java/baedalmate/baedalmate/service/RecruitService.java
@@ -5,6 +5,7 @@ import baedalmate.baedalmate.domain.Recruit;
 import baedalmate.baedalmate.repository.RecruitJpaRepository;
 import baedalmate.baedalmate.repository.RecruitRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -50,14 +51,15 @@ public class RecruitService {
 
     public List<Recruit> findAllByCategory(Long categoryId, Pageable pageable) {
         String sort = pageable.getSort().toString();
+        Pageable p = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
         if(sort.contains("score")) {
-            return recruitJpaRepository.findAllByCategoryUsingJoinOrderByScore(categoryId, pageable);
+            return recruitJpaRepository.findAllByCategoryUsingJoinOrderByScore(categoryId, p);
         }
         if(sort.contains("deadlineDate")) {
-            return recruitJpaRepository.findAllByCategoryUsingJoinOrderByDeadlineDate(categoryId, pageable);
+            return recruitJpaRepository.findAllByCategoryUsingJoinOrderByDeadlineDate(categoryId, p);
         }
         if(sort.contains("view")) {
-            return recruitJpaRepository.findAllByCategoryUsingJoinOrderByView(categoryId, pageable);
+            return recruitJpaRepository.findAllByCategoryUsingJoinOrderByView(categoryId, p);
         }
         return new ArrayList<Recruit>();
     }

--- a/src/main/java/baedalmate/baedalmate/service/RecruitService.java
+++ b/src/main/java/baedalmate/baedalmate/service/RecruitService.java
@@ -28,7 +28,10 @@ public class RecruitService {
     }
 
     public Recruit findById(Long recruitId) {
-        return recruitRepository.findOne(recruitId);
+        if(recruitJpaRepository.findById(recruitId).isEmpty()){
+            // 예외 던져야함
+        }
+        return recruitJpaRepository.findById(recruitId).get();
     }
 
     public List<Recruit> findAll(Pageable pageable) {

--- a/src/main/java/baedalmate/baedalmate/service/RecruitService.java
+++ b/src/main/java/baedalmate/baedalmate/service/RecruitService.java
@@ -31,6 +31,7 @@ public class RecruitService {
         if(recruitJpaRepository.findById(recruitId).isEmpty()){
             // 예외 던져야함
         }
+        recruitJpaRepository.updateView(recruitId);
         return recruitJpaRepository.findById(recruitId).get();
     }
 


### PR DESCRIPTION
## 개요
- 모집글 상세 조회 기능의 n+1 문제 해결
- 엔티티 id 생성 전략 변경 (auto increasement)

## 작업사항
- 모든 Entity의 @GeneratedValue 어노테이션에 GenerationType.IDENTITY 추가
- 모집글 상세 조회 메서드를 jpql로 구현
- 모집글 조회수 증가 메서드 구현

## 변경로직
- 모집글 상세 조회 시 RecruitService에서 모집글 조회수 증가 메서드 실행
