### PR TITLE
Feature/175 nickname length

### DIFF
--- a/src/main/java/baedalmate/baedalmate/security/oauth2/provider/AccessTokenAuthenticationProvider.java
+++ b/src/main/java/baedalmate/baedalmate/security/oauth2/provider/AccessTokenAuthenticationProvider.java
@@ -51,6 +51,7 @@ public class AccessTokenAuthenticationProvider implements AuthenticationProvider
         if (userBySocial.isPresent())
             return userBySocial.get();
         else {
+            String nickname = oAuth2User.getUsername().length()>5? oAuth2User.getUsername().substring(0, 5) : oAuth2User.getUsername();
             User user = User.builder()
                     .socialType(oAuth2User.getSocialType())
                     .socialId(oAuth2User.getSocialId())

--- a/src/main/java/baedalmate/baedalmate/user/service/UserService.java
+++ b/src/main/java/baedalmate/baedalmate/user/service/UserService.java
@@ -1,5 +1,6 @@
 package baedalmate.baedalmate.user.service;
 
+import baedalmate.baedalmate.errors.exceptions.InvalidApiRequestException;
 import baedalmate.baedalmate.recruit.domain.Dormitory;
 import baedalmate.baedalmate.user.domain.User;
 import baedalmate.baedalmate.errors.exceptions.InvalidParameterException;
@@ -47,6 +48,9 @@ public class UserService {
     public UserInfoDto update(Long id, String nickname) {
         User user = userJpaRepository.findById(id).get();
 
+        if(nickname.length() > 5) {
+            throw new InvalidApiRequestException("Length must be less than 6.");
+        }
         if(nickname != null && nickname != "") {
             user.setNickname(nickname);
         }


### PR DESCRIPTION
## 개요
- 유저 닉네임 길이 제한

## 작업사항
- 회원가입 시 유저 닉네임 길이가 5를 초과할 경우 길이 5 만큼만 저장
- 유저 닉네임 수정 시 길이가 5를 넘어가면 예외
