### PR TITLE
Feature/177 apple login

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation 'mysql:mysql-connector-java'
     runtimeOnly 'com.h2database:h2'
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
+    implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '3.1.1'
 
     //websocket
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
@@ -50,6 +51,10 @@ dependencies {
     implementation 'org.webjars.bower:vue:2.5.16'
     implementation 'org.webjars.bower:axios:0.17.1'
     implementation 'com.google.code.gson:gson:2.8.0'
+
+    // https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk16
+    implementation 'org.bouncycastle:bcpkix-jdk15on:1.48'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/baedalmate/baedalmate/BaedalmateApplication.java
+++ b/src/main/java/baedalmate/baedalmate/BaedalmateApplication.java
@@ -4,12 +4,14 @@ import baedalmate.baedalmate.config.AppProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 import javax.annotation.PostConstruct;
 import java.util.TimeZone;
 
 @EnableConfigurationProperties(AppProperties.class)
 @SpringBootApplication
+@EnableFeignClients
 public class BaedalmateApplication {
 
     @PostConstruct

--- a/src/main/java/baedalmate/baedalmate/config/FeignConfig.java
+++ b/src/main/java/baedalmate/baedalmate/config/FeignConfig.java
@@ -1,0 +1,11 @@
+package baedalmate.baedalmate.config;
+
+import feign.Logger;
+import org.springframework.context.annotation.Bean;
+
+public class FeignConfig {
+    @Bean
+    Logger.Level feignLoggerLevel() {
+        return Logger.Level.FULL;
+    }
+}

--- a/src/main/java/baedalmate/baedalmate/security/oauth2/authentication/AccessTokenSocialTypeToken.java
+++ b/src/main/java/baedalmate/baedalmate/security/oauth2/authentication/AccessTokenSocialTypeToken.java
@@ -15,7 +15,10 @@ public class AccessTokenSocialTypeToken extends AbstractAuthenticationToken {
 
     private String accessToken;
     private SocialType socialType;
-
+    private String identityToken;
+    private String authorizationCode;
+    private String username;
+    private String email;
 
     public AccessTokenSocialTypeToken(String accessToken, SocialType socialType) {
         super(null);
@@ -24,6 +27,15 @@ public class AccessTokenSocialTypeToken extends AbstractAuthenticationToken {
         setAuthenticated(false);
     }
 
+    public AccessTokenSocialTypeToken(String identityToken, String authorizationCode, String username, String email, SocialType socialType) {
+        super(null);
+        this.identityToken = identityToken;
+        this.authorizationCode = authorizationCode;
+        this.username = username;
+        this.email = email;
+        this.socialType = socialType;
+        setAuthenticated(false);
+    }
 
     @Builder
     public AccessTokenSocialTypeToken(Object principal, Collection<? extends GrantedAuthority> authorities) {
@@ -35,6 +47,22 @@ public class AccessTokenSocialTypeToken extends AbstractAuthenticationToken {
 
     public String getAccessToken() {
         return accessToken;
+    }
+
+    public String getIdentityToken() {
+        return identityToken;
+    }
+
+    public String getAuthorizationCode() {
+        return authorizationCode;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getEmail() {
+        return email;
     }
 
     public SocialType getSocialType() {

--- a/src/main/java/baedalmate/baedalmate/security/oauth2/client/AppleClient.java
+++ b/src/main/java/baedalmate/baedalmate/security/oauth2/client/AppleClient.java
@@ -1,0 +1,18 @@
+package baedalmate.baedalmate.security.oauth2.client;
+
+import baedalmate.baedalmate.config.FeignConfig;
+import baedalmate.baedalmate.security.oauth2.dto.ApplePublicKeyResponse;
+import baedalmate.baedalmate.security.oauth2.dto.AppleToken;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@FeignClient(name = "appleClient", url = "https://appleid.apple.com/auth", configuration = FeignConfig.class)
+public interface AppleClient {
+    @GetMapping(value = "/keys")
+    ApplePublicKeyResponse getAppleAuthPublicKey();
+
+    @PostMapping(value = "/token", consumes = "application/x-www-form-urlencoded")
+    AppleToken.Response getToken(AppleToken.Request request);
+
+}

--- a/src/main/java/baedalmate/baedalmate/security/oauth2/dto/ApplePublicKeyResponse.java
+++ b/src/main/java/baedalmate/baedalmate/security/oauth2/dto/ApplePublicKeyResponse.java
@@ -1,0 +1,30 @@
+package baedalmate.baedalmate.security.oauth2.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+import java.util.Optional;
+
+@Getter
+@Setter
+public class ApplePublicKeyResponse {
+    private List<Key> keys;
+
+    @Getter
+    @Setter
+    public static class Key {
+        private String kty;
+        private String kid;
+        private String use;
+        private String alg;
+        private String n;
+        private String e;
+    }
+
+    public Optional<Key> getMatchedKeyBy(String kid, String alg) {
+        return this.keys.stream()
+                .filter(key -> key.getKid().equals(kid) && key.getAlg().equals(alg))
+                .findFirst();
+    }
+}

--- a/src/main/java/baedalmate/baedalmate/security/oauth2/dto/AppleToken.java
+++ b/src/main/java/baedalmate/baedalmate/security/oauth2/dto/AppleToken.java
@@ -1,0 +1,54 @@
+package baedalmate.baedalmate.security.oauth2.dto;
+
+import lombok.Setter;
+public class AppleToken {
+
+    @Setter
+    public static class Request {
+        private String code;
+        private String client_id;
+        private String client_secret;
+        private String grant_type;
+        private String refresh_token;
+
+        public static Request of(String code, String clientId, String clientSecret, String grantType, String refreshToken) {
+            Request request = new Request();
+            request.code = code;
+            request.client_id = clientId;
+            request.client_secret = clientSecret;
+            request.grant_type = grantType;
+            request.refresh_token = refreshToken;
+            return request;
+        }
+    }
+
+    @Setter
+    public static class Response {
+        private String access_token;
+        private String expires_in;
+        private String id_token;
+        private String refresh_token;
+        private String token_type;
+        private String error;
+
+        public String getAccessToken() {
+            return access_token;
+        }
+
+        public String getExpiresIn() {
+            return expires_in;
+        }
+
+        public String getIdToken() {
+            return id_token;
+        }
+
+        public String getRefreshToken() {
+            return refresh_token;
+        }
+
+        public String getTokenType() {
+            return token_type;
+        }
+    }
+}

--- a/src/main/java/baedalmate/baedalmate/security/oauth2/dto/AppleUserInfo.java
+++ b/src/main/java/baedalmate/baedalmate/security/oauth2/dto/AppleUserInfo.java
@@ -1,5 +1,6 @@
 package baedalmate.baedalmate.security.oauth2.dto;
 
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -11,6 +12,7 @@ public class AppleUserInfo implements OAuth2UserInfo {
     }
 
     public AppleUserInfo(String name, String email, String socialId) {
+        this.attributes = new HashMap<>();
         attributes.put("name", name);
         attributes.put("email", email);
         attributes.put("id", socialId);

--- a/src/main/java/baedalmate/baedalmate/security/oauth2/dto/AppleUserInfo.java
+++ b/src/main/java/baedalmate/baedalmate/security/oauth2/dto/AppleUserInfo.java
@@ -1,0 +1,44 @@
+package baedalmate.baedalmate.security.oauth2.dto;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class AppleUserInfo implements OAuth2UserInfo {
+    private Map<String, Object> attributes;
+
+    public AppleUserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    public AppleUserInfo(String name, String email, String socialId) {
+        attributes.put("name", name);
+        attributes.put("email", email);
+        attributes.put("id", socialId);
+    }
+
+    @Override
+    public String getSocialId() {
+        return attributes.get("id").toString();
+    }
+
+    @Override
+    public String getName() {
+        return (String) attributes.get("name");
+    }
+
+    @Override
+    public String getEmail() {
+        LinkedHashMap<String, Object> kakaoAccount = (LinkedHashMap<String, Object>) attributes.get("kakao_account");
+        return (String) kakaoAccount.get("email");
+    }
+
+    @Override
+    public String getImage() {
+        return "";
+    }
+
+    @Override
+    public String getSocialType() {
+        return "apple";
+    }
+}

--- a/src/main/java/baedalmate/baedalmate/security/oauth2/exception/RsaNotFoundException.java
+++ b/src/main/java/baedalmate/baedalmate/security/oauth2/exception/RsaNotFoundException.java
@@ -1,0 +1,9 @@
+package baedalmate.baedalmate.security.oauth2.exception;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class RsaNotFoundException extends AuthenticationException {
+    public RsaNotFoundException() {
+        super("Can not find available rsa");
+    };
+}

--- a/src/main/java/baedalmate/baedalmate/security/oauth2/filter/OAuth2AccessTokenAuthenticationFilter.java
+++ b/src/main/java/baedalmate/baedalmate/security/oauth2/filter/OAuth2AccessTokenAuthenticationFilter.java
@@ -58,8 +58,6 @@ public class OAuth2AccessTokenAuthenticationFilter extends AbstractAuthenticatio
         ServletInputStream inputStream = request.getInputStream();
         String messageBody = StreamUtils.copyToString(inputStream, StandardCharsets.UTF_8);
 
-        SocialAccessToken socialAccessToken = objectMapper.readValue(messageBody, SocialAccessToken.class);
-        AppleAccessToken appleAccessToken = objectMapper.readValue(messageBody, AppleAccessToken.class);
 
         String accessToken = "";  //헤더의 AccessToken에 해당하는 값을 가져온다.
         String appleIdentityToken = "";
@@ -69,16 +67,18 @@ public class OAuth2AccessTokenAuthenticationFilter extends AbstractAuthenticatio
 
         switch (socialType.getSocialName()) {
             case ("kakao"):
+                SocialAccessToken socialAccessToken = objectMapper.readValue(messageBody, SocialAccessToken.class);
                 accessToken = socialAccessToken.getKakaoAccessToken();
                 break;
             case ("apple"):
+                AppleAccessToken appleAccessToken = objectMapper.readValue(messageBody, AppleAccessToken.class);
                 appleIdentityToken = appleAccessToken.getAppleIdentityToken();
                 appleAuthorizationCode = appleAccessToken.getAppleAuthorizationCode();
                 username = appleAccessToken.getUserName();
                 email = appleAccessToken.getEmail();
             default:
         }
-        if(socialType.getSocialName() == "apple") {
+        if (socialType.getSocialName() == "apple") {
             return this.getAuthenticationManager().authenticate(new AccessTokenSocialTypeToken(appleIdentityToken, appleAuthorizationCode, email, username, socialType));
         }
         return this.getAuthenticationManager().authenticate(new AccessTokenSocialTypeToken(accessToken, socialType));

--- a/src/main/java/baedalmate/baedalmate/security/oauth2/service/AppleLoadStrategy.java
+++ b/src/main/java/baedalmate/baedalmate/security/oauth2/service/AppleLoadStrategy.java
@@ -1,0 +1,109 @@
+package baedalmate.baedalmate.security.oauth2.service;
+
+import baedalmate.baedalmate.security.oauth2.client.AppleClient;
+import baedalmate.baedalmate.security.oauth2.dto.ApplePublicKeyResponse;
+import baedalmate.baedalmate.security.oauth2.dto.AppleToken;
+import baedalmate.baedalmate.security.oauth2.dto.AppleUserInfo;
+import baedalmate.baedalmate.security.oauth2.dto.OAuth2UserInfo;
+import baedalmate.baedalmate.security.oauth2.exception.ExpiredAccessTokenException;
+import baedalmate.baedalmate.security.oauth2.exception.RsaNotFoundException;
+import baedalmate.baedalmate.security.oauth2.soical.SocialType;
+import baedalmate.baedalmate.security.oauth2.util.AppleJwtUtils;
+import com.google.gson.*;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.util.ObjectUtils;
+import org.springframework.web.client.HttpClientErrorException;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.math.BigInteger;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.spec.RSAPublicKeySpec;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Base64;
+import java.util.Date;
+import java.util.Map;
+import java.util.Objects;
+
+@RequiredArgsConstructor
+@Component
+public class AppleLoadStrategy {
+
+    @Value("${apple.key.id}")
+    private String keyId;
+
+    @Value("${apple.team.id}")
+    private String teamId;
+
+    @Value("${apple.aud}")
+    private String clientId;
+
+    @Value("${apple.key.path}")
+    private String keyPath;
+
+    private final AppleClient appleClient;
+
+    private final AppleJwtUtils appleJwtUtils;
+
+    public OAuth2UserInfo getUserInfo(String identityToken, String authorizationCode, String username, String email)  {
+        try {
+            Claims userInfo = appleJwtUtils.getClaimsBy(identityToken);
+            String clientSecret = makeClientSecret();
+            AppleToken.Response response = appleClient.getToken(AppleToken.Request.of(authorizationCode, clientId, clientSecret, "authorization_code", ""));
+            JsonParser parser = new JsonParser();
+            JsonObject userInfoObject = (JsonObject) parser.parse(new Gson().toJson(userInfo));
+            JsonElement appleAlg = userInfoObject.get("sub");
+            String userId = appleAlg.getAsString();
+            return new AppleUserInfo(username, email, userId);
+        } catch (HttpClientErrorException | IOException e) {
+            throw new ExpiredAccessTokenException();
+        }
+    }
+
+    private String makeClientSecret() throws IOException {
+        Date expirationDate = Date.from(LocalDateTime.now().plusDays(30).atZone(ZoneId.systemDefault()).toInstant());
+        return Jwts.builder()
+                .setHeaderParam("kid", keyId)
+                .setHeaderParam("alg", "ES256")
+                .setIssuer(teamId)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(expirationDate)
+                .setAudience("https://appleid.apple.com")
+                .setSubject(clientId)
+                .signWith(SignatureAlgorithm.ES256, getPrivateKey())
+                .compact();
+    }
+
+    private PrivateKey getPrivateKey() throws IOException {
+        ClassPathResource resource = new ClassPathResource(keyPath);
+        String privateKey = new String(Files.readAllBytes(Paths.get(resource.getURI())));
+        Reader pemReader = new StringReader(privateKey);
+        PEMParser pemParser = new PEMParser(pemReader);
+        JcaPEMKeyConverter converter = new JcaPEMKeyConverter();
+        PrivateKeyInfo object = (PrivateKeyInfo) pemParser.readObject();
+        return converter.getPrivateKey(object);
+    }
+}

--- a/src/main/java/baedalmate/baedalmate/security/oauth2/service/AppleLoadStrategy.java
+++ b/src/main/java/baedalmate/baedalmate/security/oauth2/service/AppleLoadStrategy.java
@@ -68,7 +68,7 @@ public class AppleLoadStrategy {
 
     private final AppleJwtUtils appleJwtUtils;
 
-    public OAuth2UserInfo getUserInfo(String identityToken, String authorizationCode, String username, String email)  {
+    public OAuth2UserInfo getUserInfo(String identityToken, String authorizationCode, String email, String username)  {
         try {
             Claims userInfo = appleJwtUtils.getClaimsBy(identityToken);
             String clientSecret = makeClientSecret();

--- a/src/main/java/baedalmate/baedalmate/security/oauth2/service/LoadUserService.java
+++ b/src/main/java/baedalmate/baedalmate/security/oauth2/service/LoadUserService.java
@@ -16,7 +16,7 @@ public class LoadUserService {
     private final RestTemplate restTemplate = new RestTemplate();
 
     private SocialLoadStrategy socialLoadStrategy;//추상 클래스, 로그인을 진행하는 사이트레 따라 달라짐
-
+    private final AppleLoadStrategy appleLoadStrategy; //애플 로그인 용
 
     public OAuth2UserDetails getOAuth2UserDetails(AccessTokenSocialTypeToken authentication) throws AuthenticationException {
 
@@ -24,7 +24,12 @@ public class LoadUserService {
 
         setSocialLoadStrategy(socialType);//SocialLoadStrategy 설정
 
-        OAuth2UserInfo userInfo = socialLoadStrategy.getUserInfo(authentication.getAccessToken());//PK 가져오기
+        OAuth2UserInfo userInfo;
+        if(authentication.getSocialType().getSocialName() == "apple"){
+            userInfo = appleLoadStrategy.getUserInfo(authentication.getIdentityToken(), authentication.getAuthorizationCode(), authentication.getUsername(), authentication.getEmail());
+        } else {
+            userInfo = socialLoadStrategy.getUserInfo(authentication.getAccessToken());//PK 가져오기
+        }
 
         return OAuth2UserDetails.builder() //PK와 SocialType을 통해 회원 생성
                 .socialId(userInfo.getSocialId())
@@ -38,6 +43,8 @@ public class LoadUserService {
         switch (socialType) {
             case KAKAO:
                 this.socialLoadStrategy = new KakaoLoadStrategy();
+                break;
+            case APPLE:
                 break;
             default:
                 throw new IllegalArgumentException("지원하지 않는 로그인 형식입니다");

--- a/src/main/java/baedalmate/baedalmate/security/oauth2/soical/SocialType.java
+++ b/src/main/java/baedalmate/baedalmate/security/oauth2/soical/SocialType.java
@@ -3,6 +3,11 @@ package baedalmate.baedalmate.security.oauth2.soical;
 import org.springframework.http.HttpMethod;
 
 public enum SocialType {
+    APPLE(
+            "apple",
+            "https://appleid.apple.com/auth/keys",
+            HttpMethod.GET
+    ),
     KAKAO(
             "kakao",
             "https://kapi.kakao.com/v2/user/me",

--- a/src/main/java/baedalmate/baedalmate/security/oauth2/util/AppleJwtUtils.java
+++ b/src/main/java/baedalmate/baedalmate/security/oauth2/util/AppleJwtUtils.java
@@ -22,7 +22,6 @@ public class AppleJwtUtils {
     private final AppleClient appleClient;
 
     public Claims getClaimsBy(String identityToken) {
-
         try {
             ApplePublicKeyResponse response = appleClient.getAppleAuthPublicKey();
 
@@ -42,16 +41,15 @@ public class AppleJwtUtils {
             PublicKey publicKey = keyFactory.generatePublic(publicKeySpec);
 
             return Jwts.parser().setSigningKey(publicKey).parseClaimsJws(identityToken).getBody();
-
         } catch (NoSuchAlgorithmException e) {
         } catch (InvalidKeySpecException e) {
-        } catch (SignatureException e ){
+        } catch (SignatureException e) {
             //토큰 서명 검증
-        } catch(MalformedJwtException e) {
+        } catch (MalformedJwtException e) {
             // 구조 문제 (Invalid token)
-        } catch(ExpiredJwtException e){
+        } catch (ExpiredJwtException e) {
             //토큰이 만료됐기 때문에 클라이언트는 토큰을 refresh 해야함.
-        } catch(Exception e){
+        } catch (Exception e) {
         }
         return Jwts.parser().setSigningKey("").parseClaimsJws(identityToken).getBody();
     }

--- a/src/main/java/baedalmate/baedalmate/security/oauth2/util/AppleJwtUtils.java
+++ b/src/main/java/baedalmate/baedalmate/security/oauth2/util/AppleJwtUtils.java
@@ -1,0 +1,58 @@
+package baedalmate.baedalmate.security.oauth2.util;
+
+import baedalmate.baedalmate.security.oauth2.client.AppleClient;
+import baedalmate.baedalmate.security.oauth2.dto.ApplePublicKeyResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class AppleJwtUtils {
+    private final AppleClient appleClient;
+
+    public Claims getClaimsBy(String identityToken) {
+
+        try {
+            ApplePublicKeyResponse response = appleClient.getAppleAuthPublicKey();
+
+            String headerOfIdentityToken = identityToken.substring(0, identityToken.indexOf("."));
+            Map<String, String> header = new ObjectMapper().readValue(new String(Base64.getDecoder().decode(headerOfIdentityToken), "UTF-8"), Map.class);
+            ApplePublicKeyResponse.Key key = response.getMatchedKeyBy(header.get("kid"), header.get("alg"))
+                    .orElseThrow(() -> new NullPointerException("Failed get public key from apple's id server."));
+
+            byte[] nBytes = Base64.getUrlDecoder().decode(key.getN());
+            byte[] eBytes = Base64.getUrlDecoder().decode(key.getE());
+
+            BigInteger n = new BigInteger(1, nBytes);
+            BigInteger e = new BigInteger(1, eBytes);
+
+            RSAPublicKeySpec publicKeySpec = new RSAPublicKeySpec(n, e);
+            KeyFactory keyFactory = KeyFactory.getInstance(key.getKty());
+            PublicKey publicKey = keyFactory.generatePublic(publicKeySpec);
+
+            return Jwts.parser().setSigningKey(publicKey).parseClaimsJws(identityToken).getBody();
+
+        } catch (NoSuchAlgorithmException e) {
+        } catch (InvalidKeySpecException e) {
+        } catch (SignatureException e ){
+            //토큰 서명 검증
+        } catch(MalformedJwtException e) {
+            // 구조 문제 (Invalid token)
+        } catch(ExpiredJwtException e){
+            //토큰이 만료됐기 때문에 클라이언트는 토큰을 refresh 해야함.
+        } catch(Exception e){
+        }
+        return Jwts.parser().setSigningKey("").parseClaimsJws(identityToken).getBody();
+    }
+}


### PR DESCRIPTION
## 개요
- 애플 로그인 구현

## 작업사항
- OAuth2AuthenticationFilter에 애플 로그인 로직 추가

## 변경로직
1. 애플 로그인 요청 시 
   - identityToken, authorizationCode, name, email 전달받음(name, email은 최초 로그인 시)
 2. 애플에 public key 요청받아 identityToken 디코드, 디코드 된 토큰으로부터 유저 id 받아옴.
 3. clientSecret 생성 후 authorizationCode와 함께 애플에 accessToken, refreshToken 요청, 유효성 확인
 4. OAuth2UserInfo를 상속받은 AppleUserInfo(물론 OAuth2 표준이 아니지만 타 소셜 로그인 과정과 통일성을 위해 상속) 객체 생성