### PR TITLE
Hotfix/294 update recruit 500

### DIFF
--- a/src/main/java/baedalmate/baedalmate/recruit/dao/MenuJpaRepository.java
+++ b/src/main/java/baedalmate/baedalmate/recruit/dao/MenuJpaRepository.java
@@ -8,7 +8,6 @@ import org.springframework.data.repository.query.Param;
 
 public interface MenuJpaRepository extends JpaRepository<Menu, Long> {
     @Modifying(clearAutomatically = true)
-    @Query("delete from Menu m where m in " +
-            "(select m from Order o join o.menus m where o.id = :orderId)")
+    @Query("delete from Menu m where m.order = :orderId")
     void deleteByOrderId(@Param("orderId") Long orderId);
 }

--- a/src/main/java/baedalmate/baedalmate/recruit/dao/MenuJpaRepository.java
+++ b/src/main/java/baedalmate/baedalmate/recruit/dao/MenuJpaRepository.java
@@ -8,6 +8,6 @@ import org.springframework.data.repository.query.Param;
 
 public interface MenuJpaRepository extends JpaRepository<Menu, Long> {
     @Modifying(clearAutomatically = true)
-    @Query("delete from Menu m where m.order = :orderId")
+    @Query("delete from Menu m where m.order.id = :orderId")
     void deleteByOrderId(@Param("orderId") Long orderId);
 }

--- a/src/main/java/baedalmate/baedalmate/recruit/dao/RecruitCustomRepositoryImpl.java
+++ b/src/main/java/baedalmate/baedalmate/recruit/dao/RecruitCustomRepositoryImpl.java
@@ -171,7 +171,6 @@ public class RecruitCustomRepositoryImpl implements RecruitCustomRepository {
                 .from(recruit).distinct()
                 .join(recruit.user)
                 .leftJoin(recruit.orders)
-                .where(recruit.cancel.eq(false), recruit.fail.eq(false))
                 .where(recruit.user.id.ne(userId))
                 .where(recruit.orders.any().user.id.eq(userId))
                 .orderBy(recruit.createDate.desc())
@@ -186,7 +185,6 @@ public class RecruitCustomRepositoryImpl implements RecruitCustomRepository {
                 .from(recruit).distinct()
                 .join(recruit.user)
                 .leftJoin(recruit.orders)
-                .where(recruit.cancel.eq(false), recruit.fail.eq(false))
                 .where(recruit.user.id.eq(userId))
                 .fetchCount();
 
@@ -210,7 +208,6 @@ public class RecruitCustomRepositoryImpl implements RecruitCustomRepository {
                 .from(recruit).distinct()
                 .join(recruit.user)
                 .leftJoin(recruit.orders)
-                .where(recruit.cancel.eq(false), recruit.fail.eq(false))
                 .where(recruit.user.id.eq(userId))
                 .orderBy(recruit.createDate.desc())
                 .offset(pageable.getOffset())
@@ -224,7 +221,6 @@ public class RecruitCustomRepositoryImpl implements RecruitCustomRepository {
                 .from(recruit).distinct()
                 .join(recruit.user)
                 .leftJoin(recruit.orders)
-                .where(recruit.cancel.eq(false), recruit.fail.eq(false))
                 .where(recruit.user.id.eq(userId))
                 .fetchCount();
 

--- a/src/main/java/baedalmate/baedalmate/recruit/dao/ShippingFeeJpaRepository.java
+++ b/src/main/java/baedalmate/baedalmate/recruit/dao/ShippingFeeJpaRepository.java
@@ -8,7 +8,6 @@ import org.springframework.data.repository.query.Param;
 
 public interface ShippingFeeJpaRepository extends JpaRepository<ShippingFee, Long> {
     @Modifying(clearAutomatically = true)
-    @Query("delete from ShippingFee sf where sf in " +
-            "(select sf from Recruit r join r.shippingFees sf where r.id = :id)")
+    @Query("delete from ShippingFee sf where sf.recruit.id = :id")
     void deleteByRecruitId(@Param("id") Long recruitId);
 }

--- a/src/main/java/baedalmate/baedalmate/recruit/dao/TagJpaRepository.java
+++ b/src/main/java/baedalmate/baedalmate/recruit/dao/TagJpaRepository.java
@@ -8,7 +8,6 @@ import org.springframework.data.repository.query.Param;
 
 public interface TagJpaRepository extends JpaRepository<Tag, Long> {
     @Modifying(clearAutomatically = true)
-    @Query("delete from Tag t where t in " +
-            "(select t from Recruit r join r.tags t where r.id = :id)")
-    void deleteByRecruitId(@Param("id") Long recruitId);
+    @Query("delete from Tag t where t.recruit.id = :recruitId")
+    void deleteByRecruitId(@Param("recruitId") Long recruitId);
 }

--- a/src/main/java/baedalmate/baedalmate/recruit/service/RecruitService.java
+++ b/src/main/java/baedalmate/baedalmate/recruit/service/RecruitService.java
@@ -191,8 +191,8 @@ public class RecruitService {
         if (updateRecruitDto.getTags().size() > 4) {
             throw new InvalidParameterException("Number of tag must be less than 5");
         }
+        tagJpaRepository.deleteByRecruitId(recruitId);
         if (updateRecruitDto.getTags().size() > 0) {
-            tagJpaRepository.deleteByRecruitId(recruitId);
             List<Tag> tags = updateRecruitDto.getTags().stream()
                     .map(t -> {
 


### PR DESCRIPTION
## 개요
- 모집글 수정 500에러 해결

## 작업사항
- 삭제 쿼리 중 서브쿼리가 mysql에서 호환되지 않음. 서브쿼리 삭제
- 주최/참여한 모집글에 취소/실패한 모집글 포함